### PR TITLE
fix init script to allow multiple join addresses

### DIFF
--- a/templates/default/serf_service.erb
+++ b/templates/default/serf_service.erb
@@ -20,7 +20,7 @@ SERF_RPC_ADDRESS=<%= node["serf"]["rpc_address"]%>
 SERF_BIND_ADDRESS=<%= node["serf"]["bind_address"]%>
 SERF_LOG_LEVEL=<%= node["serf"]["log_level"] %>
 SERF_AGENT_LOG=<%= node["serf"]["log_directory"] %>/agent.log
-SERF_JOIN_ADDRESSES=<%= node["serf"]["join_addresses"].join " " %>
+SERF_JOIN_ADDRESSES="<%= node["serf"]["join_addresses"].join " " %>"
 SERF_EVENT_HANDLERS="<%= @event_handlers %>"
 
 SLEEP_TIME=5


### PR DESCRIPTION
Hi and thanks for your work on a serf cookbook! :)

Right now, having an array with more than one entry in `node[:serf][:join_addresses]` leads to an invalid init script, this commit should fix that.

Cheers
Stephan
