### PR TITLE
Fixed logging of serf agent messages when /bin/sh is not a symlinked bash.

### DIFF
--- a/templates/default/serf_service.erb
+++ b/templates/default/serf_service.erb
@@ -26,7 +26,7 @@ start() {
 	findPid
 	
 	if [ "" = "$FOUND_PID" ]; then
-      su -l $SERF_USER -c "$SERF_BINARY agent -config-file $SERF_AGENT_CONF_FILE &>> $SERF_AGENT_LOG &"
+      su -l $SERF_USER -c "$SERF_BINARY agent -config-file $SERF_AGENT_CONF_FILE >>$SERF_AGENT_LOG 2>&1 &"
       
       if [[ $? -ne 0 ]]; then
         echo "Error starting $NAME"


### PR DESCRIPTION
When running on a system where `/bin/sh` is not a symlink to `/bin/bash` (eg. Ubuntu), messages from the serf agent are displayed on the terminal rather than in `$SERF_AGENT_LOG` as expected. I traced the bug to the use of `&>>` in the service script, which according to "man bash" is shortcut to the more compatible `>>$SERF_AGENT_LOG 2>&1`.
