### PR TITLE
Reload serf agent with "kill -HUP" instead of broken "kill -SIGHUP".

### DIFF
--- a/templates/default/serf_service.erb
+++ b/templates/default/serf_service.erb
@@ -84,7 +84,7 @@ reload() {
   if [ -z "$FOUND_PID" ]; then
     echo "$NAME is not running" ; exit 1
   else
-    su -l $SERF_USER -c "kill -SIGHUP $FOUND_PID"
+    su -l $SERF_USER -c "kill -HUP $FOUND_PID"
     echo "Reloaded $NAME" 
   fi
 }


### PR DESCRIPTION
Fixed typo in the service script that broke the graceful reload feature.
