### PR TITLE
Prettify serf agent json (humans too read configuration files).

### DIFF
--- a/libraries/serf_helper.rb
+++ b/libraries/serf_helper.rb
@@ -48,7 +48,7 @@ class Chef::Recipe::SerfHelper < Chef::Recipe
   end
   
   def getAgentJson
-    node["serf"]["agent"].to_hash.to_json
+    JSON.pretty_generate(node["serf"]["agent"].to_hash)
   end
   
   def getZipFilePath


### PR DESCRIPTION
Because single-line configuration files get more and more difficult to read as they grow...

``` json
{
  "event_handlers": [
    "/opt/serf/event_handlers/test-handler.sh"
  ],
  "bind": "0.0.0.0:7946",
  "start_join": [
    "192.168.0.11",
    "192.168.0.14",
    "192.168.0.10",
    "192.168.0.13",
    "192.168.0.12"
  ]
}
```
