### PR TITLE
Updates serf download url to official repo

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,4 +1,4 @@
-# coding: UTF-8 
+# coding: UTF-8
 
 default["serf"]["user"] = "serf"
 default["serf"]["group"] = "serf"
@@ -10,8 +10,8 @@ default["serf"]["agent"]["event_handlers"] = []
 
 default["serf"]["event_handlers"] = []
 
-default["serf"]["base_binary_url"] = "https://dl.bintray.com/mitchellh/serf/"
-default["serf"]["version"] = "0.3.0"
+default["serf"]["base_binary_url"] = "https://releases.hashicorp.com/serf/"
+default["serf"]["version"] = "0.7.0"
 default['serf']['arch'] = kernel['machine'] =~ /x86_64/ ? "amd64" : "386"
 
 default["serf"]["base_directory"] = "/opt/serf"

--- a/libraries/serf_helper.rb
+++ b/libraries/serf_helper.rb
@@ -11,7 +11,7 @@ class Chef::Recipe::SerfHelper < Chef::Recipe
     super(chef_recipe.cookbook_name, chef_recipe.recipe_name, chef_recipe.run_context)
 
     # TODO: Support other distributions besides 'linux'
-    node.default["serf"]["binary_url"] = File.join node["serf"]["base_binary_url"], "#{node["serf"]["version"]}_linux_#{node["serf"]["arch"]}.zip"
+    node.default["serf"]["binary_url"] = File.join node["serf"]["base_binary_url"], "#{node["serf"]["version"]}", "serf_#{node["serf"]["version"]}_linux_#{node["serf"]["arch"]}.zip"
 
     current_version = get_serf_installed_version
     if current_version


### PR DESCRIPTION
Bintray serf links are not working anymore. I have updated the URL to official hashcorp downloads.