### PR TITLE
Initialize SerfHelper Differently to Avoid compat_resource Cookbook Conflict

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -10,9 +10,11 @@ default["serf"]["agent"]["event_handlers"] = []
 
 default["serf"]["event_handlers"] = []
 
-default["serf"]["base_binary_url"] = "https://releases.hashicorp.com/serf/"
 default["serf"]["version"] = "0.7.0"
 default['serf']['arch'] = kernel['machine'] =~ /x86_64/ ? "amd64" : "386"
+
+default["serf"]["base_binary_url"] = "https://releases.hashicorp.com/serf/"
+default["serf"]["binary_url"] = nil
 
 default["serf"]["base_directory"] = "/opt/serf"
 default["serf"]["log_directory"] = "/var/log/serf"

--- a/libraries/serf_helper.rb
+++ b/libraries/serf_helper.rb
@@ -1,22 +1,15 @@
 # coding: UTF-8
 require 'json'
 
-class Chef::Recipe::SerfHelper < Chef::Recipe
+class Chef::Recipe::SerfHelper
 
   SERF_VERSION_REGEX = /^Serf v\d.\d.\d/
   VERSION_REGEX = /\d.\d.\d/
 
-  # Initializes the helper class
-  def initialize chef_recipe
-    super(chef_recipe.cookbook_name, chef_recipe.recipe_name, chef_recipe.run_context)
+  attr_accessor :node
 
-    # TODO: Support other distributions besides 'linux'
-    node.default["serf"]["binary_url"] = File.join node["serf"]["base_binary_url"], "#{node["serf"]["version"]}", "serf_#{node["serf"]["version"]}_linux_#{node["serf"]["arch"]}.zip"
-
-    current_version = get_serf_installed_version
-    if current_version
-      Chef::Log.info "Current Serf Version : [#{current_version}]"
-    end
+  def initialize(node)
+    @node = node
   end
 
   def get_bin_directory

--- a/libraries/serf_helper.rb
+++ b/libraries/serf_helper.rb
@@ -45,7 +45,11 @@ class Chef::Recipe::SerfHelper
   end
 
   def get_zip_file_path
-    File.join Chef::Config[:file_cache_path], "serf-#{node["serf"]["version"]}_linux_#{node["serf"]["arch"]}.zip"
+    File.join Chef::Config[:file_cache_path], get_binary_filename
+  end
+
+  def get_binary_url
+    File.join node["serf"]["base_binary_url"], node["serf"]["version"], get_binary_filename
   end
 
   def get_serf_installed_version
@@ -70,4 +74,9 @@ class Chef::Recipe::SerfHelper
     version_match[0]
   end
 
+  private
+
+  def get_binary_filename
+    "serf_#{node["serf"]["version"]}_linux_#{node["serf"]["arch"]}.zip"
+  end
 end

--- a/libraries/serf_helper.rb
+++ b/libraries/serf_helper.rb
@@ -49,7 +49,8 @@ class Chef::Recipe::SerfHelper
   end
 
   def get_binary_url
-    File.join node["serf"]["base_binary_url"], node["serf"]["version"], get_binary_filename
+    node["serf"]["binary_url"] ||
+    File.join(node["serf"]["base_binary_url"], node["serf"]["version"], get_binary_filename)
   end
 
   def get_serf_installed_version

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -47,7 +47,7 @@ end
 # Download binary zip file
 remote_file helper.get_zip_file_path do
   action :create_if_missing
-  source node["serf"]["binary_url"]
+  source helper.get_binary_url
   group node["serf"]["group"]
   owner node["serf"]["user"]
   mode 00644

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -7,7 +7,7 @@
 include_recipe 'logrotate'
 
 # Initializes the serf_helper class by giving it access to `node`
-helper = SerfHelper.new self
+helper = SerfHelper.new node
 
 # Create serf user/group
 group node["serf"]["group"] do


### PR DESCRIPTION
[`compat_resource`](https://github.com/chef-cookbooks/compat_resource) "brings the [custom resource](https://docs.chef.io/custom_resources.html) creation syntax from Chef 12.5 to earlier Chef 12.X releases." This is starting to become a common dependency in many library cookbooks such as the [docker cookbook](https://github.com/chef-cookbooks/docker/blob/master/metadata.rb#L11).

Unfortunately, the way `SerfHelper` is being initialized causes errors when both dependencies exist. This PR resolves the conflict by taking a slightly different approach to initializing it without changing behavior.